### PR TITLE
A handful of fixes/tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,10 @@ ARG BLUEMAP_VERSION=3.20
 USER root
 
 # Install dependencies
-RUN apk add --no-cache curl unzip
+RUN apk add --no-cache curl php83-pdo php83-pdo_mysql unzip
+
+# Install useful tools
+RUN apk add --no-cache bind-tools iputils vim
 
 # Download and extract BlueMap.jar to temporary directory
 RUN tmpdir=$(mktemp -d) && \
@@ -21,13 +24,13 @@ RUN tmpdir=$(mktemp -d) && \
     rm -rf "${tmpdir}"
 
 # Patch sql.php to use database credentials from environment variables
-RUN sed -i "s/\$driver   = .*/$driver   = getenv('DB_DRIVER') ?: 'mysql';/" /var/www/html/sql.php && \
-    sed -i "s/\$hostname = .*/$hostname = getenv('DB_HOST') ?: '127.0.0.1';/" /var/www/html/sql.php && \
-    sed -i "s/\$port     = .*/$port     = getenv('DB_PORT') ?: 3306;/" /var/www/html/sql.php && \
-    sed -i "s/\$username = .*/$username = getenv('DB_USER') ?: 'root';/" /var/www/html/sql.php && \
-    sed -i "s/\$password = .*/$password = getenv('DB_PASSWORD') ?: '';/" /var/www/html/sql.php && \
-    sed -i "s/\$database = .*/$database = getenv('DB_NAME') ?: 'bluemap';/" /var/www/html/sql.php && \
-    sed -i "s/\$hiresCompression = .*/$hiresCompression = getenv('HIRES_COMPRESSION') ?: 'gzip';/" /var/www/html/sql.php
+RUN sed -i "s/\$driver   = .*/\$driver   = getenv('DB_DRIVER') ?: 'mysql';/" /var/www/html/sql.php && \
+    sed -i "s/\$hostname = .*/\$hostname = getenv('DB_HOST') ?: '127.0.0.1';/" /var/www/html/sql.php && \
+    sed -i "s/\$port     = .*/\$port     = getenv('DB_PORT') ?: 3306;/" /var/www/html/sql.php && \
+    sed -i "s/\$username = .*/\$username = getenv('DB_USER') ?: 'root';/" /var/www/html/sql.php && \
+    sed -i "s/\$password = .*/\$password = getenv('DB_PASSWORD') ?: '';/" /var/www/html/sql.php && \
+    sed -i "s/\$database = .*/\$database = getenv('DB_NAME') ?: 'bluemap';/" /var/www/html/sql.php && \
+    sed -i "s/\$hiresCompression = .*/\$hiresCompression = getenv('HIRES_COMPRESSION') ?: 'gzip';/" /var/www/html/sql.php
 
 # Copy nginx configuration
 COPY config/nginx.conf /etc/nginx/nginx.conf

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ services:
     depends_on:
       - mariadb
     environment:
-      MYSQL_HOST: mariadb
-      MYSQL_PORT: '3306'
-      MYSQL_USER: bluemap
-      MYSQL_PASSWORD: thisisaverysecurepassword
-      MYSQL_DATABASE: bluemap
+      DB_DRIVER: mariadb
+      DB_HOST: mariadb
+      DB_PORT: '3306'
+      DB_USER: bluemap
+      DB_PASSWORD: thisisaverysecurepassword
+      DB_NAME: bluemap
     volumes:
       - ./data/settings.json:/var/www/html/settings.json
 
@@ -43,11 +44,12 @@ You can also deploy this image using the following command:
 docker run -d \
   --name bluemap \
   -p 8100:80/tcp \
-  -e MYSQL_HOST=mariadb \
-  -e MYSQL_PORT=3306 \
-  -e MYSQL_USER=bluemap \
-  -e MYSQL_PASSWORD=thisisaverysecurepassword \
-  -e MYSQL_DATABASE=bluemap \
+  -e DB_DRIVER=mariadb \
+  -e DB_HOST=mariadb \
+  -e DB_PORT=3306 \
+  -e DB_USER=bluemap \
+  -e DB_PASSWORD=thisisaverysecurepassword \
+  -e DB_NAME=bluemap \
   -v ./data/settings.json:/var/www/html/settings.json \
   divadsn/bluemap-nginx:latest
 ```
@@ -55,16 +57,17 @@ docker run -d \
 Note that in both cases, you need to create a `settings.json` file in the `./data` directory. You can also find this file in the BlueMap webroot directory.
 
 ## Environment variables
-| Variable | Description | Default value |
-| --- | --- | --- |
-| `MYSQL_HOST` | Hostname of the MySQL server | `127.0.0.1` |
-| `MYSQL_PORT` | Port of the MySQL server | `3306` |
-| `MYSQL_USER` | Username of the MySQL user | `root` |
-| `MYSQL_PASSWORD` | Password of the MySQL user | `""` |
-| `MYSQL_DATABASE` | Name of the MySQL database | `bluemap` |
+| Variable      | Description                     | Default value |
+|---------------|---------------------------------|---------------|
+| `DB_DRIVER`   | Type of database                | `mysql`       |
+| `DB_HOST`     | Hostname of the database server | `127.0.0.1`   |
+| `DB_PORT`     | Port of the database server     | `3306`        |
+| `DB_USER`     | Username of the database user   | `root`        |
+| `DB_PASSWORD` | Password of the database user   | `""`          |
+| `DB_NAME`     | Name of the database database   | `bluemap`     |
 
 ## Limitations
 - This image does not support HTTPS out of the box. You need to modify the Nginx `default.conf` in order to enable HTTPS or use a reverse proxy.
-- You need to enable `write-markers-interval` and `write-players-interval` in BlueMap in order for live data to be written to the database.
+- You need to enable `write-markers-interval` and `write-players-interval` in BlueMap in order for live data to be written to the database.  This will incur a lot of writes to your database, however.
 
-You can also modify the `default.conf` to [proxy live data requests](https://bluemap.bluecolored.de/wiki/webserver/ExternalWebserversSQL.html) to the BlueMap integrated webserver.
+You can also modify the `default.conf` to [proxy live data requests](https://bluemap.bluecolored.de/wiki/webserver/ExternalWebserversSQL.html) to the BlueMap integrated webserver.  This is the recommended method for external services to access live player locations.

--- a/config/conf.d/default.conf
+++ b/config/conf.d/default.conf
@@ -4,11 +4,11 @@ server {
     server_name _;
 
     root /var/www/html;
-    index index.php index.html;
+    index index.html index.php;
 
     # First attempt to serve request as file, then as directory, then fall back to mysql.php
     location / {
-        try_files $uri $uri/ /mysql.php;
+        try_files $uri $uri/ /sql.php;
     }
 
     # Pass the PHP scripts to PHP-FPM listening on php-fpm.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,12 @@ services:
     depends_on:
       - mariadb
     environment:
-      MYSQL_HOST: mariadb
-      MYSQL_PORT: '3306'
-      MYSQL_USER: bluemap
-      MYSQL_PASSWORD: thisisaverysecurepassword
-      MYSQL_DATABASE: bluemap
+      DB_DRIVER: mariadb
+      DB_HOST: mariadb
+      DB_PORT: '3306'
+      DB_USER: bluemap
+      DB_PASSWORD: thisisaverysecurepassword
+      DB_DATABASE: bluemap
     volumes:
       - ./data/settings.json:/var/www/html/settings.json
 


### PR DESCRIPTION
This was a great starting point for me, but I had to make some changes to get things to work (plus a adding a few packages that are more quality of life improvements for troubleshooting).

Of note:
- `Dockerfile`
  - The unescaped `$`'s in the `sed` commands breaks the `sql.php` file
  - Adding the PHP PDO for mysql to the image, since without this I was getting PHP errors trying to talk to the DB
- `default.conf`
  - Fixing the misnamed `mysql.php` reference 
  - Switching the order of `index.php` and `index.html` so that just going to your FQDN defaults to the `index.html` page and loads your BlueMap instance, instead of defaulting to the PHP index page.
- Updating documentation to match the `env`'s in the `docker-compose` and `docker run` examples, etc. to the Dockerfile `sed` environment variable names.